### PR TITLE
Fix GetPage logic

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -5,14 +5,11 @@
 and <code>post02.md</code>, and it does under 0.64 or lower.</p>
 <p>Under 0.65+, it ignores <code>post02.md</code>.</p>
 {{ range $key := slice "post01" "post02" }}
-  {{$.Scratch.Set "foo" (printf "%s.md" $key)}}
-  {{ with $.Site.GetPage "/posts"}}
-    {{ with .GetPage ($.Scratch.Get "foo") }}
+    {{ with site.GetPage $key }}
       <h3>{{ .Title }}</h3>
       <p>{{ .File.Path }}</p>
     {{end}}
-  {{end}}
-{{end}}
+ {{end}}
   </article>
   {{/* Define a section to pull recent posts from. For Hugo 0.20 this will default to the section with the most number of pages. */}}
   {{ $mainSections := .Site.Params.mainSections | default (slice "post") }}


### PR DESCRIPTION
Note that the outer GetPage to get the section was superflous for pages in sub dir even in Hugo 0.64, as it would fall back to a "name only" lookup.

This is still the behaviour for rel/relRef shortcode, but as this is extremely confusing for people doing a `.GetPage "somepage"` and then get a page from a totally different section instead of the expected nil (not found).